### PR TITLE
Update ai-project.bicep

### DIFF
--- a/infra/ai-project.bicep
+++ b/infra/ai-project.bicep
@@ -117,7 +117,7 @@ resource hub 'Microsoft.MachineLearningServices/workspaces@2024-10-01' = {
     keyVault: keyVault.outputs.resourceId
     hbiWorkspace: false
     managedNetwork: {
-      isolationMode: 'Disabled'
+      isolationMode: 'AllowInternetOutBound'
     }
     v1LegacyMode: false
     publicNetworkAccess: 'Enabled'


### PR DESCRIPTION
Update bicep to support H100 deployment

# Purpose

Update bicep to support H100 Deployment 
At present any H100 deployment outside of eastus/eastus2/westeurope 

Requires to be a vnet or compute deployment will fail

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x ] No
```

## Does this require changes to learn.microsoft.com docs or modules?

which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
